### PR TITLE
Update AppTask.cpp

### DIFF
--- a/examples/energy-management-app/silabs/src/AppTask.cpp
+++ b/examples/energy-management-app/silabs/src/AppTask.cpp
@@ -172,7 +172,7 @@ void ApplicationShutdown()
 #endif // CONFIG_ENABLE_EXAMPLE_EVSE_DEVICE
 
 #if SL_CONFIG_ENABLE_EXAMPLE_WATER_HEATER_DEVICE
-    FullWhmApplicationShutdown();
+    WaterHeaterApplicationShutdown();
 #endif // CONFIG_ENABLE_EXAMPLE_WATER_HEATER_DEVICE
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 }


### PR DESCRIPTION
Fix ApplicationShutdown for WaterHeater.
Otherwise there is an error build error:
```
./scripts/examples/gn_silabs_example.sh ./examples/energy-management-app/silabs/ ./out/waterheater-app BRD2703A
(edit)
../../../examples/energy-management-app/silabs/src/AppTask.cpp: In function 'void ApplicationShutdown()':
../../../examples/energy-management-app/silabs/src/AppTask.cpp:175:5: error: 'FullWhmApplicationShutdown' was not declared in this scope; did you mean 'EvseApplicationShutdown'?
  175 |     FullWhmApplicationShutdown();
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |     EvseApplicationShutdown
```
