### PR TITLE
Fix Compute Engine integration / conformance dashboard

### DIFF
--- a/integrations/compute_engine/startup-script.sh
+++ b/integrations/compute_engine/startup-script.sh
@@ -28,7 +28,7 @@ cd connectedhomeip
 
 # Generate Conformance Report
 source scripts/activate.sh
-./scripts/build_python.sh -i out/python_env
+./scripts/build_python.sh -w false -i out/python_env
 python3 -u scripts/examples/conformance_report.py
 cp /tmp/conformance_report/conformance_report.html out/coverage/coverage/html
 


### PR DESCRIPTION
#### Summary

The conformance tests dashboard is broken https://matter-build-automation.ue.r.appspot.com/conformance_report.html

It seems there's an issue with the build of the python environment and `libdatachannel`.

Since we don't need webrtc for those tests, I'll disable it in the python build. This seems to fix the issue.


#### Testing
Tested it fixed the issue on my local environment.